### PR TITLE
Adjust frame size constants

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -4,6 +4,16 @@
 SERIAL_PORT = 'COM7'
 BAUD_RATE = 9600
 
+# Camera-instellingen
+# Pas de resolutie aan een 4:3 formaat. Indien een andere
+# cameraresolutie wordt gebruikt moet ook MM_PER_PIXEL opnieuw
+# worden bepaald voor correcte metingen.
+FRAME_WIDTH = 1600
+FRAME_HEIGHT = 1200
+PIXEL_FORMAT = 0  # standaardwaarde, indien nodig aanpassen
+EXPOSURE_TIME = 5000.0
+GAIN = 0.0
+
 # MySQL database instellingen (productiegebruik)
 DB_CONFIG = {
     'host': 'mysql.kvdelsen.nl',


### PR DESCRIPTION
## Summary
- set camera frame width/height to a 4:3 resolution in `config.py`
- document recalibration note for `MM_PER_PIXEL`
- expose basic camera settings so modules can read them

## Testing
- `python -m py_compile config/config.py logic/camera_module.py ui/dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_684008fe246083229c525cde10a73fdc