### PR TITLE
Fix imports and add serial rotation command

### DIFF
--- a/logic/autonomous_flow.py
+++ b/logic/autonomous_flow.py
@@ -3,8 +3,6 @@ from logic.box_identifier import identify_box
 from logic.orientation_solver import solve_orientation
 from serial.arduino_comm import send_rotation_command
 from ui.dashboard import update_dashboard_status
-from sensor.height_sensor import HeightSensorReader
-from config.config import ROTATE_LOGIC_VERBOSE
 
 # Wordt ingesteld vanuit main
 CAMERA = None

--- a/logic/box_identifier.py
+++ b/logic/box_identifier.py
@@ -1,5 +1,5 @@
 from database.sql_interface import get_all_boxes
-from config.config import MATCH_TOLERANCE_LB, MATCH_TOLERANCE_H, WEIGHTS
+from config.config import MATCH_TOLERANCE_LB, WEIGHTS
 
 def identify_box(measured_length, measured_width, measured_height):
     # Herken vorm op basis van verhouding lengte/breedte

--- a/main/main.py
+++ b/main/main.py
@@ -1,12 +1,11 @@
-from PyQt5.QtWidgets import QApplication
-from ui.dashboard import Dashboard
-from logic.autonomous_flow import run_cycle
 import sys
+from PyQt5.QtWidgets import QApplication
+
+from ui.dashboard import LiveFeedDashboard
 
 def main():
     app = QApplication(sys.argv)
-    dashboard = Dashboard()
-    dashboard.start_callback = lambda: run_cycle(dashboard.update_dashboard)
+    dashboard = LiveFeedDashboard()
     dashboard.show()
     sys.exit(app.exec_())
 

--- a/serial/arduino_comm.py
+++ b/serial/arduino_comm.py
@@ -37,3 +37,27 @@ class ArduinoComm:
     def close(self):
         if self.ser:
             self.ser.close()
+
+
+def send_rotation_command(angle, flip="none"):
+    """Stuur een rotatiecommando naar de Arduino.
+
+    Parameters
+    ----------
+    angle : float or int
+        Hoek in graden voor servo-kanaal 0.
+    flip : str, optional
+        Type flip, standaard ``"none"``. Wordt alleen gelogd.
+    """
+
+    arduino = ArduinoComm()
+    if not arduino.ser:
+        return None
+
+    response = arduino.send_command(f"ROTATE 0 {int(angle)}")
+
+    if flip and flip.lower() != "none":
+        arduino.send_command(f"# Flip not supported: {flip}")
+
+    arduino.close()
+    return response

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
 )
-from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtCore import QTimer
 from PyQt5.QtGui import QPixmap, QImage
 import cv2
 


### PR DESCRIPTION
## Summary
- fix entrypoint to use `LiveFeedDashboard`
- remove unused imports and add missing send_rotation_command helper
- clean up unused Qt import

## Testing
- `pyflakes main/main.py logic/autonomous_flow.py logic/box_identifier.py ui/dashboard.py serial/arduino_comm.py`
- `find main logic serial ui -name '*.py' | xargs python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_684012151a948322b64523f5943496a0