### PR TITLE
Fix circular import in autonomous flow

### DIFF
--- a/logic/autonomous_flow.py
+++ b/logic/autonomous_flow.py
@@ -2,13 +2,13 @@ from logic.camera_module import detect_box_dimensions, convert_frame_to_opencv
 from logic.box_identifier import identify_box
 from logic.orientation_solver import solve_orientation
 from arduino_comm.arduino_comm import send_rotation_command
-from ui.dashboard import update_dashboard_status
 
 # Wordt ingesteld vanuit main
 CAMERA = None
 HEIGHT_READER = None
 
 def run_autonomous_cycle():
+    from ui.dashboard import update_dashboard_status
     print("=== ROTATION SYSTEM: AUTONOME CYCLE START ===")
     update_dashboard_status("Wachten op boxdetectie...")
 


### PR DESCRIPTION
## Summary
- fix circular import between `ui.dashboard` and `logic.autonomous_flow`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main/main.py` *(fails: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_68402bd2b1048322a391586fcd145e08