### PR TITLE
Fix frame grab call

### DIFF
--- a/logic/autonomous_flow.py
+++ b/logic/autonomous_flow.py
@@ -1,4 +1,8 @@
-from logic.camera_module import detect_box_dimensions, convert_frame_to_opencv
+from logic.camera_module import (
+    detect_box_dimensions,
+    convert_frame_to_opencv,
+    get_frame_tuple,
+)
 from logic.box_identifier import identify_box
 from logic.orientation_solver import solve_orientation
 from arduino_comm.arduino_comm import send_rotation_command
@@ -22,8 +26,8 @@ def run_autonomous_cycle():
         print("[FLOW] Hoogtesensor ontbreekt")
         return
 
-    frame_tuple = CAMERA.MV_CC_GetOneFrameTimeout(2000)
-    if not frame_tuple:
+    frame_tuple = get_frame_tuple(CAMERA)
+    if not frame_tuple or frame_tuple[1] is None:
         update_dashboard_status("Geen cameraframe ontvangen.")
         return
 

--- a/ui/dashboard.py
+++ b/ui/dashboard.py
@@ -14,7 +14,7 @@ import cv2
 
 import logic.autonomous_flow as autonomous_flow
 from logic.autonomous_flow import run_autonomous_cycle
-from logic.camera_module import convert_frame_to_opencv, init_camera
+from logic.camera_module import convert_frame_to_opencv, init_camera, get_frame_tuple
 from sensor.height_sensor import HeightSensorReader
 
 
@@ -109,8 +109,8 @@ class LiveFeedDashboard(QWidget):
     def update_camera_frame(self):
         if autonomous_flow.CAMERA is None:
             return
-        frame_tuple = autonomous_flow.CAMERA.MV_CC_GetOneFrameTimeout(2000)
-        if not frame_tuple:
+        frame_tuple = get_frame_tuple(autonomous_flow.CAMERA)
+        if not frame_tuple or frame_tuple[1] is None:
             return
         image = convert_frame_to_opencv(frame_tuple)
         if image is not None:


### PR DESCRIPTION
## Summary
- add a safer `get_frame_tuple` helper
- use `get_frame_tuple` in the dashboard and flow logic for capturing frames

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684030918b748322b597023dbafb9409